### PR TITLE
add docker compose yaml

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,13 @@
+services:
+  drone:
+    volumes:
+      - ../drone_2024:/drone_2024
+    image: "ros:iron"
+    command: bash -c "tail -f /dev/null"
+    # deploy:
+    #   resources:
+    #     reservations:
+    #       devices:
+    #         - driver: nvidia
+    #           count: 1
+    #           capabilities: [gpu]


### PR DESCRIPTION
This add a docker compose file to the root directory. After installing docker, by running `docker compose up` in the root directory, docker will spin up a container containing ros2. If you have the docker and remote development vscode extensions, you can attach a vscode window that is entirely in the container. Open a terminal in this vscode window and run `source /opt/ros/iron/setup.bash`. Now run `ros2` and see that the command exists.

Docker works great on linux and max machines and alright on windows machines. This method will quickly get members setup with ros2. I'm opening this PR to give you guys the option of using docker, but you don't have to use it. There are pros and cons. The main con is that it is very minimal. To get graphical apps, network stuff, and hardware interfaces to work requires effort. The benefits are that it is very simple to setup, and runs on the jetson without any hacking.